### PR TITLE
typo in config.js

### DIFF
--- a/public_html/server/config/config.js
+++ b/public_html/server/config/config.js
@@ -2746,7 +2746,6 @@ Node.Config.prototype.setAppData = function (params, callback)
 Node.Config.prototype.sendToLicServer = async function (operation, data, format = "json")
 {
   console.error("NOT SUPPORTED FOR SELF");
-}
 };
 
 


### PR DESCRIPTION
riga 2750 file /idcloud/idserver/server/config/config.js

c'è una chiusa quadra di troppo.